### PR TITLE
fix hd repo url and ks install method

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -11,9 +11,14 @@
 
 # Get started
 
-通过 brew 安装: `brew install linuxsuren/linuxsuren/hd`
+通过 brew 安装: `brew install linuxsuren/linuxsuren/ks`
 
-通过 [hd](https://github.com/linuxsuren/http-downloader) 安装: `hd install kubesphere-sigs/ks`
+通过 [hd](https://github.com/linuxsuren/http-downloader) 安装: 
+
+```
+brew install linuxsuren/linuxsuren/hd
+hd install kubesphere-sigs/ks
+```
 
 # 特色功能
 

--- a/README-zh.md
+++ b/README-zh.md
@@ -11,9 +11,9 @@
 
 # Get started
 
-通过 brew 安装: `brew install kubesphere-sigs/kubesphere-sigs/ks`
+通过 brew 安装: `brew install linuxsuren/linuxsuren/hd`
 
-通过 [hd](https://github.com/kubesphere-sigs/http-downloader) 安装: `hd install kubesphere-sigs/ks`
+通过 [hd](https://github.com/linuxsuren/http-downloader) 安装: `hd install kubesphere-sigs/ks`
 
 # 特色功能
 

--- a/README.md
+++ b/README.md
@@ -11,11 +11,12 @@
 
 # Get started
 
-Install it via: `brew install linuxsuren/linuxsuren/hd`
+Install it via: `brew install linuxsuren/linuxsuren/ks`
 
 Install it via [hd](https://github.com/linuxsuren/http-downloader):
 
 ```
+brew install linuxsuren/linuxsuren/hd
 hd install kubesphere-sigs/ks
 ```
 

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@
 
 # Get started
 
-Install it via: `brew install kubesphere-sigs/kubesphere-sigs/ks`
+Install it via: `brew install linuxsuren/linuxsuren/hd`
 
-Install it via [hd](https://github.com/kubesphere-sigs/http-downloader):
+Install it via [hd](https://github.com/linuxsuren/http-downloader):
 
 ```
 hd install kubesphere-sigs/ks


### PR DESCRIPTION
1. The hd tool don't contribute to kubesphere, so I think it's still using the author's tool address
2. hd is a great tool, hd itself already provides a brew installation method, ks installation can be done with the help of hd, covering the installation scene, so I think you can remove the brew directly install ks command