### PR TITLE
Add a global flag --context to pass k8s context

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/huandu/xstrings v1.3.2 // indirect
 	github.com/linuxsuren/cobra-extension v0.0.10
-	github.com/linuxsuren/go-cli-alias v0.0.6
+	github.com/linuxsuren/go-cli-alias v0.0.7
 	github.com/linuxsuren/http-downloader v0.0.35
 	github.com/mitchellh/copystructure v1.1.1 // indirect
 	github.com/spf13/cobra v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -362,8 +362,8 @@ github.com/linuxsuren/cobra-extension v0.0.3/go.mod h1:UqHi31q7Dj+46nzcVWNZz5Z1J
 github.com/linuxsuren/cobra-extension v0.0.6/go.mod h1:qcEJv7BbL0UpK6MbrTESP/nKf1+z1wQdMAnE1NBl3QQ=
 github.com/linuxsuren/cobra-extension v0.0.10 h1:ciZDb2Bp/aAFqr4YoeVuH2uyBaBFfO6pwz1WBih7R4A=
 github.com/linuxsuren/cobra-extension v0.0.10/go.mod h1:nDsXgvm0lSWVV+byAEfwhIGFDoIp0Sq9wkfNUDBp5do=
-github.com/linuxsuren/go-cli-alias v0.0.6 h1:PGYf1xqy5GzGINeRhiZR1PTlp09cbyC66MGcXp+iC1Q=
-github.com/linuxsuren/go-cli-alias v0.0.6/go.mod h1:Sa7xNUI72BgHTcywDU8MXVSH1q72SLdMALZSSANwuUM=
+github.com/linuxsuren/go-cli-alias v0.0.7 h1:Il870YXx17VF4wTh+r/JXAKdtwY/0pVNWXL/wuNfuOw=
+github.com/linuxsuren/go-cli-alias v0.0.7/go.mod h1:Sa7xNUI72BgHTcywDU8MXVSH1q72SLdMALZSSANwuUM=
 github.com/linuxsuren/http-downloader v0.0.2-0.20201207132639-19888a6beaec/go.mod h1:zRZY9FCDBuYNDxbI2Ny5suasZsMk7J6q9ecQ3V3PIqI=
 github.com/linuxsuren/http-downloader v0.0.6/go.mod h1:xxgh2OE7WGL9TwDE9L8Gh7Lqq9fFPuHbh5tofUitEfE=
 github.com/linuxsuren/http-downloader v0.0.35 h1:hZ+ctSWdhSej5C5nbpHKYEFCh72q30qwfvAin+XYtz4=

--- a/kubectl-plugin/common/client.go
+++ b/kubectl-plugin/common/client.go
@@ -1,9 +1,11 @@
 package common
 
 import (
+	"context"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 
+	"fmt"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
 
@@ -16,4 +18,42 @@ func GetClient() (client dynamic.Interface, clientSet *kubernetes.Clientset, err
 	}
 
 	return
+}
+
+// GetDynamicClient get the dynamic k8s client from context
+func GetDynamicClient(ctx context.Context) (client dynamic.Interface) {
+	factory := ctx.Value(ClientFactory{})
+	client, _ = factory.(*ClientFactory).GetClient()
+	return
+}
+
+// ClientFactory is for getting k8s client
+type ClientFactory struct {
+	//client    dynamic.Interface
+	//clientSet *kubernetes.Clientset
+	context string
+}
+
+// GetClient returns k8s client
+func (c *ClientFactory) GetClient() (client dynamic.Interface, clientSet *kubernetes.Clientset) {
+	KubernetesConfigFlags := genericclioptions.NewConfigFlags(false)
+	if c.context != "" {
+		KubernetesConfigFlags.Context = &c.context
+	}
+	if config, err := KubernetesConfigFlags.ToRESTConfig(); err == nil {
+		client, err = dynamic.NewForConfig(config)
+		if err != nil {
+			fmt.Println(err)
+		}
+		clientSet, err = kubernetes.NewForConfig(config)
+		if err != nil {
+			fmt.Println(err)
+		}
+	}
+	return
+}
+
+// SetContext sets the k8s context
+func (c *ClientFactory) SetContext(ctx string) {
+	c.context = ctx
 }

--- a/kubectl-plugin/entrypoint/cmd.go
+++ b/kubectl-plugin/entrypoint/cmd.go
@@ -43,7 +43,10 @@ KubeSphere is the enterprise-grade container platform tailored for multicloud an
 See also https://github.com/kubesphere/kubesphere`,
 		PersistentPreRunE: opt.persistentPreRunE,
 	}
-	cmd.PersistentFlags().StringVarP(&opt.context, "context", "c", "", "")
+	cmd.SetOut(streams.Out)
+	cmd.SetErr(streams.ErrOut)
+	cmd.PersistentFlags().StringVarP(&opt.context, "context", "", "",
+		"Sets a context entry in kubeconfig")
 
 	var err error
 	var client dynamic.Interface

--- a/kubectl-plugin/entrypoint/cmd.go
+++ b/kubectl-plugin/entrypoint/cmd.go
@@ -23,14 +23,27 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
+type rootOpt struct {
+	context string
+}
+
+func (o *rootOpt) persistentPreRunE(cmd *cobra.Command, args []string) (err error) {
+	factory := cmd.Context().Value(common.ClientFactory{})
+	factory.(*common.ClientFactory).SetContext(o.context)
+	return
+}
+
 // NewCmdKS returns the root command of kubeclt-ks
 func NewCmdKS(streams genericclioptions.IOStreams) (cmd *cobra.Command) {
+	opt := &rootOpt{}
 	cmd = &cobra.Command{
 		Use: "ks",
 		Short: `kubectl plugin for KubeSphere
 KubeSphere is the enterprise-grade container platform tailored for multicloud and multi-cluster management
 See also https://github.com/kubesphere/kubesphere`,
+		PersistentPreRunE: opt.persistentPreRunE,
 	}
+	cmd.PersistentFlags().StringVarP(&opt.context, "context", "c", "", "")
 
 	var err error
 	var client dynamic.Interface

--- a/kubectl-plugin/kubectl-ks.go
+++ b/kubectl-plugin/kubectl-ks.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"context"
+	"github.com/kubesphere-sigs/ks/kubectl-plugin/common"
 	"github.com/kubesphere-sigs/ks/kubectl-plugin/entrypoint"
 	"github.com/spf13/pflag"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
@@ -16,7 +18,7 @@ func main() {
 		Out:    os.Stdout,
 		ErrOut: os.Stderr,
 	})
-	if err := root.Execute(); err != nil {
+	if err := root.ExecuteContext(context.WithValue(context.TODO(), common.ClientFactory{}, &common.ClientFactory{})); err != nil {
 		os.Exit(1)
 	}
 }

--- a/kubectl-plugin/pipeline/root.go
+++ b/kubectl-plugin/pipeline/root.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/AlecAivazis/survey/v2"
+	"github.com/kubesphere-sigs/ks/kubectl-plugin/common"
 	"github.com/kubesphere-sigs/ks/kubectl-plugin/types"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -17,6 +18,7 @@ func NewPipelineCmd(client dynamic.Interface) (cmd *cobra.Command) {
 		Aliases: []string{"pip"},
 		Short:   "Manage the Pipeline of KubeSphere DevOps",
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
+			client := common.GetDynamicClient(cmd.Context())
 			var pips []string
 			if _, pips, err = getPipelines(client, args); err == nil {
 				for _, pip := range pips {
@@ -36,7 +38,7 @@ func NewPipelineCmd(client dynamic.Interface) (cmd *cobra.Command) {
 		newPipelineEditCmd(client),
 		newPipelineViewCmd(client),
 		newPipelineCreateCmd(client),
-		newPipelineRunCmd(client),
+		newPipelineRunCmd(),
 		newGCCmd(client))
 	return
 }

--- a/kubectl-plugin/pipeline/run.go
+++ b/kubectl-plugin/pipeline/run.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"github.com/kubesphere-sigs/ks/kubectl-plugin/common"
 	"github.com/kubesphere-sigs/ks/kubectl-plugin/types"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -12,11 +13,8 @@ import (
 	"text/template"
 )
 
-func newPipelineRunCmd(client dynamic.Interface) (cmd *cobra.Command) {
-	opt := &pipelineRunOpt{
-		client:               client,
-		pipelineCreateOption: pipelineCreateOption{Client: client},
-	}
+func newPipelineRunCmd() (cmd *cobra.Command) {
+	opt := &pipelineRunOpt{}
 	cmd = &cobra.Command{
 		Use:     "run",
 		Short:   "Start a Pipeline",
@@ -49,6 +47,9 @@ type pipelineRunOpt struct {
 }
 
 func (o *pipelineRunOpt) preRunE(cmd *cobra.Command, args []string) (err error) {
+	o.client = common.GetDynamicClient(cmd.Root().Context())
+	o.pipelineCreateOption.Client = o.client
+
 	if o.pipeline == "" && len(args) > 0 {
 		o.pipeline = args[0]
 	}

--- a/main.go
+++ b/main.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"context"
 	"fmt"
+	"github.com/kubesphere-sigs/ks/kubectl-plugin/common"
 	"github.com/kubesphere-sigs/ks/kubectl-plugin/entrypoint"
 	ext "github.com/linuxsuren/cobra-extension"
 	extver "github.com/linuxsuren/cobra-extension/version"
@@ -47,8 +49,11 @@ func main() {
 			ErrOut: os.Stderr,
 		})
 		kubectlPluginCmds := kubectlPluginCmdRoot.Commands()
+		cmd.PersistentFlags().AddFlagSet(kubectlPluginCmdRoot.PersistentFlags())
+		cmd.PersistentPreRunE = kubectlPluginCmdRoot.PersistentPreRunE
 		cmd.AddCommand(kubectlPluginCmds...)
 	}
 
-	aliasCmd.Execute(cmd, targetCommand, getDefault(), nil)
+	aliasCmd.ExecuteContext(cmd, context.WithValue(context.TODO(), common.ClientFactory{}, &common.ClientFactory{}),
+		targetCommand, getDefault(), nil)
 }


### PR DESCRIPTION
With this feature, you can trigger a Pipeline in the [k9s](https://github.com/derailed/k9s) dashboard with a shortcut.

You can try the following k9s plugin config file (`~/.config/k9s/plugin.yml`):
```
plugin:
  ks:
    shortCut: o
    scopes:
    - pipeline
    command: ks
    background: false
    description: Trigger Pipeline
    args:
    - pip
    - run
    - --context
    - $CONTEXT
    - -b
    - -n
    - $NAMESPACE
    - -p
    - $NAME
```