### PR TITLE
Set a name for k3d nightly

### DIFF
--- a/kubectl-plugin/install/k3d.go
+++ b/kubectl-plugin/install/k3d.go
@@ -54,6 +54,7 @@ You can get more details from https://github.com/rancher/k3d/`,
 		"rancher/k3s:v1.20.10-k3s1",
 		"rancher/k3s:v1.21.4-k3s1"))
 	_ = cmd.RegisterFlagCompletionFunc("components", common.PluginAbleComponentsCompletion())
+	_ = cmd.RegisterFlagCompletionFunc("nightly", common.ArrayCompletion("latest"))
 	return
 }
 
@@ -71,6 +72,11 @@ type k3dOption struct {
 func (o *k3dOption) preRunE(cmd *cobra.Command, args []string) (err error) {
 	if len(args) > 0 {
 		o.name = args[0]
+	}
+
+	// make the name of nightly k3d be clear
+	if o.name == "k3s-default" && o.nightly != "" {
+		_, o.name = common.GetNightlyTag(o.nightly)
 	}
 
 	is := installer.Installer{

--- a/kubectl-plugin/install/kind.go
+++ b/kubectl-plugin/install/kind.go
@@ -42,6 +42,7 @@ ks install kind --nightly latest --components DevOps`,
 		"Indicate if fetch the latest config of tools")
 
 	_ = cmd.RegisterFlagCompletionFunc("components", common.PluginAbleComponentsCompletion())
+	_ = cmd.RegisterFlagCompletionFunc("nightly", common.ArrayCompletion("latest"))
 	return
 }
 

--- a/kubectl-plugin/install/kk.go
+++ b/kubectl-plugin/install/kk.go
@@ -46,7 +46,7 @@ ks install kk --version nightly --components devops`,
 		"Indicate if fetch the latest config of tools")
 
 	_ = cmd.RegisterFlagCompletionFunc("components", common.PluginAbleComponentsCompletion())
-	_ = cmd.RegisterFlagCompletionFunc("components", common.ArrayCompletion("docker", "containerd"))
+	_ = cmd.RegisterFlagCompletionFunc("container", common.ArrayCompletion("docker", "containerd"))
 	return
 }
 


### PR DESCRIPTION
Usage: `ks install k3d --nightly latest`

Result:
```
[root@node1 ~]# k3d cluster list
NAME               SERVERS   AGENTS   LOADBALANCER
nightly-20210926   1/1       1/1      true
```
