### PR TITLE
Support create a pipline on the dashboard page

### DIFF
--- a/kubectl-plugin/pipeline/create.go
+++ b/kubectl-plugin/pipeline/create.go
@@ -166,6 +166,21 @@ func (o *pipelineCreateOption) preRunE(cmd *cobra.Command, args []string) (err e
 		return
 	}
 
+	if err = o.parseTemplate(); err != nil {
+		return
+	}
+
+	if o.Name == "" && len(args) > 0 {
+		o.Name = args[0]
+	}
+
+	if o.Name == "" {
+		err = fmt.Errorf("please provide the name of Pipeline")
+	}
+	return
+}
+
+func (o *pipelineCreateOption) parseTemplate() (err error) {
 	switch o.Template {
 	case "":
 	case "java":
@@ -193,18 +208,10 @@ func (o *pipelineCreateOption) preRunE(cmd *cobra.Command, args []string) (err e
 		err = fmt.Errorf("%s is not support", o.Template)
 	}
 	o.Jenkinsfile = strings.TrimSpace(o.Jenkinsfile)
-
-	if o.Name == "" && len(args) > 0 {
-		o.Name = args[0]
-	}
-
-	if o.Name == "" {
-		err = fmt.Errorf("please provide the name of Pipeline")
-	}
 	return
 }
 
-func (o *pipelineCreateOption) runE(cmd *cobra.Command, args []string) (err error) {
+func (o *pipelineCreateOption) createPipeline() (err error) {
 	ctx := context.TODO()
 
 	var wdID string
@@ -228,6 +235,11 @@ func (o *pipelineCreateOption) runE(cmd *cobra.Command, args []string) (err erro
 			err = fmt.Errorf("failed to create Pipeline, %v", err)
 		}
 	}
+	return
+}
+
+func (o *pipelineCreateOption) runE(cmd *cobra.Command, args []string) (err error) {
+	err = o.createPipeline()
 	return
 }
 

--- a/kubectl-plugin/pipeline/ui/stack.go
+++ b/kubectl-plugin/pipeline/ui/stack.go
@@ -1,0 +1,46 @@
+package ui
+
+import "github.com/rivo/tview"
+
+// Stack is the stack of the views
+type Stack struct {
+	views []tview.Primitive
+	count int
+	app   *tview.Application
+}
+
+// NewStack creates a new stack instance
+func NewStack(app *tview.Application) *Stack {
+	return &Stack{app: app}
+}
+
+// Push pushes a view and show it
+func (s *Stack) Push(view tview.Primitive) {
+	s.views = append(s.views[:s.count], view)
+	s.count++
+	s.showCurrentView()
+}
+
+// Pop pops a view and show the preview one
+func (s *Stack) Pop() tview.Primitive {
+	if s.count == 0 {
+		return nil
+	}
+	s.count--
+	s.showCurrentView()
+	return s.views[s.count]
+}
+
+// GetCurrent returns the current view
+func (s *Stack) GetCurrent() tview.Primitive {
+	if s.count < 1 {
+		return nil
+	}
+	return s.views[s.count-1]
+}
+
+func (s *Stack) showCurrentView() {
+	if current := s.GetCurrent(); current != nil {
+		s.app.SetRoot(current, true)
+	}
+}


### PR DESCRIPTION
Users can create a Pipeline base on the template. You just need to type command: `ks pip dash`

then switch to the Pipeline list view, press key `c`.

![image](https://user-images.githubusercontent.com/1450685/135194585-c92dd901-b4a8-4ae9-9721-a4e598ccacdf.png)