### PR TITLE
Avoid delete whole annotation of users

### DIFF
--- a/kubectl-plugin/user/user_cmd.go
+++ b/kubectl-plugin/user/user_cmd.go
@@ -14,7 +14,7 @@ import (
 func NewUserCmd(client dynamic.Interface) (cmd *cobra.Command) {
 	cmd = &cobra.Command{
 		Use:   "user",
-		Short: "Reset the password of Kubesphere to the default value which is same with its name",
+		Short: "Reset the password of KubeSphere to the default value which is same with its name",
 		Args:  cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			name := args[0]
@@ -22,7 +22,7 @@ func NewUserCmd(client dynamic.Interface) (cmd *cobra.Command) {
 			_, err = client.Resource(kstype.GetUserSchema()).Patch(context.TODO(),
 				name,
 				types.MergePatchType,
-				[]byte(fmt.Sprintf(`{"spec":{"password":"%s"},"metadata":{"annotations":null}}`, name)),
+				[]byte(fmt.Sprintf(`{"spec":{"password":"%s"},"metadata":{"annotations":{"iam.kubesphere.io/uninitialized": "false"}}}`, name)),
 				metav1.PatchOptions{})
 			return
 		},


### PR DESCRIPTION
The test output:

```shell
root@node1:~# ks get user admin -oyaml | head
apiVersion: iam.kubesphere.io/v1alpha2
kind: User
metadata:
  annotations:
    helm.sh/resource-policy: keep
    iam.kubesphere.io/uninitialized: "true"
    meta.helm.sh/release-name: ks-core
    meta.helm.sh/release-namespace: kubesphere-system
  creationTimestamp: "2021-10-21T04:36:41Z"
  finalizers:
root@node1:~# ks user admin
root@node1:~# ks get user admin -oyaml | head
apiVersion: iam.kubesphere.io/v1alpha2
kind: User
metadata:
  annotations:
    helm.sh/resource-policy: keep
    iam.kubesphere.io/last-password-change-time: "2021-10-21T05:43:00Z"
    iam.kubesphere.io/uninitialized: "false"
    meta.helm.sh/release-name: ks-core
    meta.helm.sh/release-namespace: kubesphere-system
  creationTimestamp: "2021-10-21T04:36:41Z"
```