### PR TITLE
Fix wrong check in function getCompletionTimeFromObject

### DIFF
--- a/kubectl-plugin/pipeline/gc.go
+++ b/kubectl-plugin/pipeline/gc.go
@@ -118,7 +118,8 @@ func ascOrderWithCompletionTime(items []unstructured.Unstructured) {
 			return false
 		}
 		if rightCompletionTime, err = getCompletionTimeFromObject(right.Object); err != nil {
-			return false
+			// make sure that item without completion time be at the end of items
+			return true
 		}
 
 		return leftCompletionTime.Before(rightCompletionTime)

--- a/kubectl-plugin/pipeline/gc_test.go
+++ b/kubectl-plugin/pipeline/gc_test.go
@@ -12,10 +12,18 @@ import (
 func TestDescOrderWithCompletionTime(t *testing.T) {
 	items := []unstructured.Unstructured{{
 		Object: map[string]interface{}{
+			"flag": "3",
+		},
+	}, {
+		Object: map[string]interface{}{
 			"status": map[string]interface{}{
 				"completionTime": "2021-09-28T01:39:13Z",
 			},
 			"flag": "0",
+		},
+	}, {
+		Object: map[string]interface{}{
+			"flag": "4",
 		},
 	}, {
 		Object: map[string]interface{}{
@@ -36,6 +44,11 @@ func TestDescOrderWithCompletionTime(t *testing.T) {
 	ascOrderWithCompletionTime(items)
 	flag, _, _ := unstructured.NestedString(items[0].Object, "flag")
 	assert.Equal(t, "2", flag)
+	// make sure that object without status.completionTime be at the end of the result
+	flag, _, _ = unstructured.NestedString(items[3].Object, "flag")
+	assert.Equal(t, "3", flag)
+	flag, _, _ = unstructured.NestedString(items[4].Object, "flag")
+	assert.Equal(t, "4", flag)
 }
 
 func Test_getCompletionTimeFromObject(t *testing.T) {


### PR DESCRIPTION
### What this PR dose?

Fix wrong check in function getCompletionTimeFromObject, please see:

https://github.com/kubesphere-sigs/ks/blob/88e11d9f6d1769bd56ac56c9bf9da3bd580b9a32/kubectl-plugin/pipeline/gc.go#L131

If the ok is false and err is nil, the return value will be `time.Time{}, nil`, it's unexpected. Meanwhile, I've add related test cases for that scenario.

BTW, this will make function `ascOrderWithCompletionTime` behavior unexpectedly. So our latest PipelineRuns will be accidentally deleted.

### Why we need it?

Please see #236.

### Which issue dose this PR fix?

Fix #236.

/kind bug

