### PR TITLE
Migrate SonarQube configuration from kubesphere-config into devops-config

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/Masterminds/semver v1.5.0
 	github.com/Masterminds/sprig v2.22.0+incompatible
 	github.com/Pallinder/go-randomdata v1.2.0
+	github.com/evanphx/json-patch v4.9.0+incompatible
 	github.com/gdamore/tcell/v2 v2.4.1-0.20210905002822-f057f0a857a1
 	github.com/huandu/xstrings v1.3.2 // indirect
 	github.com/linuxsuren/cobra-extension v0.0.11

--- a/kubectl-plugin/config/migrate.go
+++ b/kubectl-plugin/config/migrate.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
+
 	"github.com/kubesphere-sigs/ks/kubectl-plugin/types"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/dynamic"
-	"strings"
 )
 
 func newMigrateCmd(client dynamic.Interface) (cmd *cobra.Command) {
@@ -54,6 +55,18 @@ func (o *migrateOption) runE(cmd *cobra.Command, args []string) (err error) {
 		return
 	}
 
+	patchData := make(map[string]interface{})
+
+	kubesphereConfig, _, err := o.getKubeSphereConfig("kubesphere-config", "kubesphere-system")
+	if err != nil {
+		return err
+	}
+	if sonarQube, found, err := unstructured.NestedMap(kubesphereConfig, "sonarQube"); err != nil {
+		return err
+	} else if found {
+		patchData["sonarQube"] = sonarQube
+	}
+
 	var password string
 	if password, err = o.getDevOpsPassword(); password == "" {
 		if err == nil {
@@ -62,35 +75,35 @@ func (o *migrateOption) runE(cmd *cobra.Command, args []string) (err error) {
 			err = fmt.Errorf("the password of Jenkins is empty, it might caused by: %v", err)
 		}
 	} else if err == nil {
-		err = o.updateKubeSphereConfig("devops-config", o.namespace, map[string]interface{}{
+		patchData["devops"] = map[string]interface{}{
 			"password": password,
-		})
+		}
 	}
-	return
+
+	return o.updateKubeSphereConfig("devops-config", o.namespace, patchData)
 }
 
-func (o *migrateOption) updateKubeSphereConfig(name, namespace string, ksdataMap map[string]interface{}) (err error) {
-	var rawConfigMap *unstructured.Unstructured
-	if rawConfigMap, err = o.client.Resource(types.GetConfigMapSchema()).Namespace(namespace).
-		Get(context.TODO(), name, metav1.GetOptions{}); err == nil {
-		data := rawConfigMap.Object["data"]
-		dataMap := data.(map[string]interface{})
-
-		result := updateAuthWithObj(dataMap["kubesphere.yaml"].(string), ksdataMap)
-		if strings.TrimSpace(result) == "" {
-			err = fmt.Errorf("error happend when parse kubesphere-config")
-			return
-		}
-
-		rawConfigMap.Object["data"] = map[string]interface{}{
-			"kubesphere.yaml": result,
-		}
-		_, err = o.client.Resource(types.GetConfigMapSchema()).Namespace(namespace).Update(context.TODO(),
-			rawConfigMap, metav1.UpdateOptions{})
-	} else {
-		err = fmt.Errorf("cannot found configmap kubesphere-config, %v", err)
+func (o *migrateOption) updateKubeSphereConfig(name, namespace string, ksdataMap map[string]interface{}) error {
+	kubeSphereConfig, rawConfigMap, err := o.getKubeSphereConfig(name, namespace)
+	if err != nil {
+		return fmt.Errorf("cannot found ConfigMap %s/%s, %v", namespace, name, err)
 	}
-	return
+
+	mergeMap(kubeSphereConfig, ksdataMap)
+	kubeSphereConfigBytes, err := yaml.Marshal(kubeSphereConfig)
+	if err != nil {
+		return fmt.Errorf("cannot marshal KubeSphere configuration, %v", err)
+	}
+
+	rawConfigMap.Object["data"] = map[string]interface{}{
+		"kubesphere.yaml": string(kubeSphereConfigBytes),
+	}
+	if _, err = o.client.Resource(types.GetConfigMapSchema()).
+		Namespace(namespace).
+		Update(context.TODO(), rawConfigMap, metav1.UpdateOptions{}); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (o *migrateOption) getDevOpsPassword() (password string, err error) {
@@ -117,23 +130,46 @@ func (o *migrateOption) getDevOpsPassword() (password string, err error) {
 	return
 }
 
-func updateAuthWithObj(yamlf string, dataMap map[string]interface{}) string {
-	mapData := make(map[string]interface{})
-	if err := yaml.Unmarshal([]byte(yamlf), mapData); err == nil {
-		var obj interface{}
-		var ok bool
-		var mapObj map[string]interface{}
-		if obj, ok = mapData["devops"]; ok {
-			mapObj = obj.(map[string]interface{})
-		} else {
-			mapObj = make(map[string]interface{})
-			mapData["devops"] = mapObj
-		}
+func (o *migrateOption) getKubeSphereConfig(configMapName, namespace string) (map[string]interface{}, *unstructured.Unstructured, error) {
+	kubesphereConfigCM, err := o.client.Resource((types.GetConfigMapSchema())).
+		Namespace(namespace).
+		Get(context.Background(), configMapName, metav1.GetOptions{})
+	if err != nil {
+		return nil, nil, fmt.Errorf("cannot found ConfigMap %s/%s, %v", namespace, configMapName, err)
+	}
+	kubesphereConfigYAMLString, found, err := unstructured.NestedString(kubesphereConfigCM.UnstructuredContent(), "data", "kubesphere.yaml")
+	if err != nil {
+		return nil, nil, err
+	}
+	if !found {
+		return nil, nil, fmt.Errorf("cannot found 'kubesphere.yaml' configuration in ConfigMap %s/%s", namespace, configMapName)
+	}
+	kubesphereConfig := make(map[string]interface{})
+	if err := yaml.Unmarshal([]byte(kubesphereConfigYAMLString), kubesphereConfig); err != nil {
+		return nil, nil, err
+	}
+	return kubesphereConfig, kubesphereConfigCM, nil
+}
 
-		for key, val := range dataMap {
-			mapObj[key] = val
+// mergeMap merges patch map into main map.
+// This function has a constriant that map types must be `map[string]interface{}`, including types of map value or map value's value.
+func mergeMap(main map[string]interface{}, patch map[string]interface{}) {
+	for patchKey, patchValue := range patch {
+		if value, ok := main[patchKey]; ok {
+			patchValueMap, patchValueOk := patchValue.(map[string]interface{})
+			valueMap, valueOk := value.(map[string]interface{})
+			if patchValueOk && valueOk {
+				// recursive check
+				mergeMap(valueMap, patchValueMap)
+			} else {
+				if reflect.TypeOf(value) == reflect.TypeOf(patchValue) {
+					// set patch value directly if one of the value type are not map[string]interface{} and both types are equal
+					main[patchKey] = patchValue
+				}
+			}
+		} else {
+			// set patch value directly if key in main is not found
+			main[patchKey] = patchValue
 		}
 	}
-	resultData, _ := yaml.Marshal(mapData)
-	return string(resultData)
 }

--- a/kubectl-plugin/config/migrate_test.go
+++ b/kubectl-plugin/config/migrate_test.go
@@ -1,0 +1,174 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+)
+
+func Test_patchKubeSphereConfig(t *testing.T) {
+	type args struct {
+		main  map[string]interface{}
+		patch map[string]interface{}
+	}
+	tests := []struct {
+		name string
+		args args
+		want map[string]interface{}
+	}{{
+		name: "Merge non-exist fields recursively",
+		args: args{
+			main: map[string]interface{}{
+				"devops": map[string]interface{}{
+					"enabled": true,
+				},
+			},
+			patch: map[string]interface{}{
+				"devops": map[string]interface{}{
+					"password": "fake password",
+				},
+			},
+		},
+		want: map[string]interface{}{
+			"devops": map[string]interface{}{
+				"enabled":  true,
+				"password": "fake password",
+			},
+		},
+	}, {
+		name: "Merge non-exist field",
+		args: args{
+			main: map[string]interface{}{
+				"devops": map[string]interface{}{
+					"enabled": true,
+				},
+			},
+			patch: map[string]interface{}{
+				"sonarQube": map[string]interface{}{
+					"token": "fake token",
+				},
+			},
+		},
+		want: map[string]interface{}{
+			"devops": map[string]interface{}{
+				"enabled": true,
+			},
+			"sonarQube": map[string]interface{}{
+				"token": "fake token",
+			},
+		},
+	}, {
+		name: "Merge existing field",
+		args: args{
+			main: map[string]interface{}{
+				"devops": map[string]interface{}{
+					"enabled": true,
+				},
+				"sonarQube": map[string]interface{}{
+					"token": "fake token",
+				},
+			},
+			patch: map[string]interface{}{
+				"devops": map[string]interface{}{
+					"enabled": false,
+				},
+			},
+		},
+		want: map[string]interface{}{
+			"devops": map[string]interface{}{
+				"enabled": false,
+			},
+			"sonarQube": map[string]interface{}{
+				"token": "fake token",
+			},
+		},
+	}, {
+		name: "Patch is nil",
+		args: args{
+			main: map[string]interface{}{
+				"devops": map[string]interface{}{
+					"enabled": true,
+				},
+			},
+			patch: nil,
+		},
+		want: map[string]interface{}{
+			"devops": map[string]interface{}{
+				"enabled": true,
+			},
+		},
+	}, {
+		name: "Main is nil",
+		args: args{
+			main:  nil,
+			patch: map[string]interface{}{},
+		},
+		want: nil,
+	}, {
+		name: "Merge with different type",
+		args: args{
+			main: map[string]interface{}{
+				"devops": map[string]interface{}{
+					"enabled": true,
+				},
+			},
+			patch: map[string]interface{}{
+				"devops": "awesome",
+			},
+		},
+		want: map[string]interface{}{
+			"devops": map[string]interface{}{
+				"enabled": true,
+			},
+		},
+	}, {
+		name: "Merge with different map type",
+		args: args{
+			main: map[string]interface{}{
+				"devops": map[string]interface{}{
+					"enabled":  true,
+					"password": "fake password",
+				},
+			},
+			patch: map[string]interface{}{
+				"devops": map[string]string{
+					"password": "patch password",
+				},
+			},
+		},
+		want: map[string]interface{}{
+			"devops": map[string]interface{}{
+				"enabled":  true,
+				"password": "fake password",
+			},
+		},
+	}, {
+		name: "Merge without map[string]interface{}",
+		args: args{
+			main: map[string]interface{}{
+				"devops": map[string]bool{
+					"enabled": true,
+				},
+			},
+			patch: map[string]interface{}{
+				"devops": map[string]bool{
+					"disabled": false,
+				},
+			},
+		},
+		want: map[string]interface{}{
+			"devops": map[string]bool{
+				"disabled": false,
+			},
+		},
+	},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mergeMap(tt.args.main, tt.args.patch)
+			if !reflect.DeepEqual(tt.args.main, tt.want) {
+				t.Errorf("mergeMap() = %v, want =  %v", tt.args.main, tt.want)
+				return
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What this PR dose

Migrate SonarQube configuration from kubesphere-config into devops-config.

### Why we need it

Please see
- https://github.com/kubesphere/ks-devops/issues/385

### Which issue this PR fixes

Fix https://github.com/kubesphere/ks-devops/issues/385

### Steps to test

1. Add SonarQube configuration part into ConfigMap `kubesphere-config`

    ```yaml
    sonarQube:
      host: http://sonarqube-sonarqube.kubesphere-devops-system:9000
      token: 4dbc5fcaad6a4fd3780fbdde53804cb251e6d2ce
    ```

1. Check ConfigMap `devops-config`

1. Run the command 

    ```bash
    go run ./kubectl-plugin/kubectl-ks.go option migrate --service devops-apiserver.kubesphere-devops-system:9090 --namespace kubesphere-devops-system
    ```

1. Check ConfigMap `devops-config` again, especially `SonarQube` configuration part

/kind bug
